### PR TITLE
일정관리 Agent : Slack API를 통한 Google Calendar 일정 추가/변경/검색/삭제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,7 @@ jspm_packages/
 
 # dotenv environment variables file
 .env 
+
+# Secret Agents secret keys
+ai-server/agents/schedule/client_secret.json
+ai-server/agents/schedule/token.json

--- a/ai-server/agents/schedule/agent_nodes.py
+++ b/ai-server/agents/schedule/agent_nodes.py
@@ -1,0 +1,820 @@
+# agent_nodes.py
+"""
+Langgraph Agent 노드 함수 정의
+이 파일은 Langgraph Agent에서 사용하는 각 노드의 비즈니스 로직을 정의합니다.
+각 노드는 AgentState를 입력으로 받아 처리 결과를 반환합니다.
+"""
+import re
+import json
+from datetime import datetime, timedelta
+import os
+import subprocess
+import sys
+
+# Google 엑세스 토큰 및 인증 관련 임포트
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+from googleapiclient.errors import HttpError
+
+# Google Calendar API 설정
+GOOGLE_CALENDAR_SCOPES = [os.getenv('GOOGLE_CALENDAR_SCOPES')]  # google_auth_setup.py에서 사용한 것과 동일한 스코프
+TARGET_CALENDAR_ID = os.getenv('GOOGLE_CALENDAR_ID')            # 캘린더 이메일 주소 (일정을 추가할 대상 캘린더의 ID)
+
+# 스크립트 경로 정의
+BASE_DIR = os.path.dirname(__file__)
+TOKEN_PATH = os.path.join(BASE_DIR, "token.json")
+CLIENT_SECRET_PATH = os.path.join(BASE_DIR, "client_secret.json")
+AUTH_SCRIPT = os.path.join(BASE_DIR, "google_auth_setup.py")  # 인증 스크립트 경로
+
+# LangGraph Agent 상태 및 OpenAI 클라이언트 임포트
+from agent_state import AgentState
+from langchain_openai import ChatOpenAI
+
+# ChatOpenAI 초기화
+llm_model = ChatOpenAI(
+    model=os.getenv("OPENAI_MODEL_NAME", "gpt-4o-mini"),
+    temperature=0.2
+)
+
+# 현재 날짜 및 시간 정보 (프롬프트 입력용)
+now = datetime.now().astimezone() # 현재 날짜와 시간
+current_datetime_str = now.strftime('%Y-%m-%d %H:%M:%S %Z')
+this_week_monday = now - timedelta(days=now.weekday())
+
+# 상대적 날짜 해석 규칙 (프롬프트 입력용)
+relative_date_guidelines = f"""
+    **상대적 날짜 표현을 아래 기준으로 해석해줘:**
+    - '오늘'은 '{now.strftime('%Y-%m-%d')}'
+    - '내일'은 '{(now + timedelta(days=1)).strftime('%Y-%m-%d')}'
+    - '모레'는 '{(now + timedelta(days=2)).strftime('%Y-%m-%d')}'
+    - '3일 뒤'는 '{(now + timedelta(days=3)).strftime('%Y-%m-%d')}'
+    - '이번주 월요일'은 '{(this_week_monday).strftime('%Y-%m-%d')}'
+    - '이번주 금요일'은 '{(this_week_monday + timedelta(days=4)).strftime('%Y-%m-%d')}'
+    - '다음주 화요일'은 '{(this_week_monday + timedelta(days=8)).strftime('%Y-%m-%d')}'
+    - '다음주 목요일'은 '{(this_week_monday + timedelta(days=10)).strftime('%Y-%m-%d')}'
+"""
+
+# 현재 FastAPI가 실행 중인 Python 인터프리터 경로를 그대로 이용
+current_python = sys.executable
+
+
+def run_google_auth_setup():
+    """
+    google_auth_setup.py를 실행하여 인증 토큰을 생성합니다.
+    """
+    try:
+        subprocess.run([sys.executable, AUTH_SCRIPT], cwd=BASE_DIR, check=True)
+        return os.path.exists(TOKEN_PATH)
+    except Exception as e:
+        print(f"[ERROR] 인증 스크립트 실행 실패: {e}")
+        return False
+
+
+# Google Calendar 서비스 객체 초기화 함수
+def get_google_calendar_service():
+    """
+    Google Calendar API 서비스 객체를 반환합니다.
+    토큰이 없거나 만료되었을 경우 자동으로 인증 스크립트를 실행합니다.
+    """
+    creds = None
+
+    # 1. token.json이 존재하면 로드
+    if os.path.exists(TOKEN_PATH):
+        try:
+            creds = Credentials.from_authorized_user_file(TOKEN_PATH, GOOGLE_CALENDAR_SCOPES)
+        except Exception as e:
+            print(f"[ERROR] token.json 로딩 중 오류 발생: {e}. 파일이 손상되었을 수 있습니다.")
+            creds = None
+            return None
+    
+    # 2. 토큰이 없거나 유효하지 않으면 인증 실행
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            # 리프레시 토큰이 유효하면 액세스 토큰 갱신
+            print("Google 액세스 토큰이 만료되어 갱신을 시도합니다...")
+
+            try:
+                creds.refresh(Request())
+
+                # 갱신된 자격 증명을 token.json 파일에 저장
+                with open(TOKEN_PATH, "w") as token:
+                    token.write(creds.to_json())
+                print("Google 액세스 토큰 갱신 성공.")
+            except Exception as e:
+                print(f"[ERROR] 토큰 갱신 실패: {e}")
+
+                print("인증 스크립트를 다시 실행합니다...")
+                if not run_google_auth_setup():
+                    return None
+                creds = Credentials.from_authorized_user_file(TOKEN_PATH, GOOGLE_CALENDAR_SCOPES)
+        else:
+            print("🔐 인증 정보 없음 또는 유효하지 않음 → 인증 시작")
+            if not run_google_auth_setup():
+                return None
+            creds = Credentials.from_authorized_user_file(TOKEN_PATH, GOOGLE_CALENDAR_SCOPES)
+
+    # 3. 서비스 객체 생성
+    try:
+        service = build("calendar", "v3", credentials=creds)
+        return service
+    except Exception as e:
+        print(f"[ERROR] Google Calendar 서비스 객체 생성 실패: {e}")
+        return None
+    
+
+# ============== 노드 함수 정의 ================ #
+def slack_message_parser(state: AgentState):
+    """
+    Slack 메시지에서 봇 멘션을 제거하고 정제된 텍스트를 추출하는 노드.
+    """
+    slack_message = state["slack_message"]
+    channel_id = state["channel_id"]
+    bot_client = state["bot_client"]
+
+    # 봇 멘션 부분을 제거하여 실제 일정 내용만 추출
+    cleaned_text = re.sub(r'<@\w+>\s*', '', slack_message).strip()
+
+    # 추출된 내용이 비어있을 경우 사용자에게 안내
+    if not cleaned_text:
+        bot_client.chat_postMessage(channel=channel_id, text=f"일정 추가를 위한 내용을 입력해주세요. 예시: `@Agent이름 내일 10시 팀 회의`")
+        return {"cleaned_message": None, "intent": "unknown", "llm_error": "No content after mention removal"} 
+    
+    # 여기서 /schedule 커맨드 예외 처리. 실제 슬래시 커맨드는 별도 핸들러에서 처리될 수 있지만,
+    # 멘션 안에 포함된 경우를 대비하여 처리.
+    if cleaned_text.lower().startswith('/schedule'):
+        bot_client.chat_postMessage(channel=channel_id, text="`/schedule` 커맨드는 현재 지원되지 않습니다. Agent를 멘션하여 일정을 입력해주세요. 예시: `@Agent이름 내일 10시 팀 회의`")
+        return {"cleaned_message": None, "intent": "unknown", "llm_error": "Unsupported command detected"} 
+    
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: slack_message_parser - 정제된 메시지: '{cleaned_text}'")
+    return {"cleaned_message": cleaned_text}
+
+
+def llm_intent_classifier(state: AgentState):
+    """
+    LLM을 사용하여 사용자의 의도(추가, 변경, 삭제)를 분류하는 노드.
+    """
+    cleaned_message = state.get("cleaned_message")
+    channel_id = state["channel_id"]
+    bot_client = state["bot_client"]
+
+    # 정제된 메시지 내용물 확인
+    if cleaned_message is None:
+        return {"intent": "unknown", "llm_error": "No cleaned message for intent classification."}
+
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: llm_intent_classifier - 의도 분류 시작")
+
+    try:
+        prompt = f"""
+            현재 시각은 {current_datetime_str}야.
+            다음 메시지의 의도를 'add'(일정 추가), 'modify'(일정 변경), 'delete'(일정 삭제), 'search'(일정 검색), 'unknown'(알 수 없음) 중 하나로 분류해줘.
+            메시지: '{cleaned_message}'
+
+            \n\n응답 형식:
+            {{"intent": "의도",
+              "query": "검색 키워드 (제목)",
+              "date": "검색 날짜 (YYYY-MM-DD)"}}\n
+            
+            예시:
+            1. "내일 오후 3시 회의 추가해줘" → {{ "intent": "add", "query": "회의", "date": "2025-08-02" }}
+            2. "다음주 목요일 회의 삭제해줘" → {{ "intent": "delete", "query": "회의", "date": "2025-08-08" }}
+            3. "이번주 금요일 일정 알려줘" → {{ "intent": "search", "query": "일정", "date": "2025-08-02" }}
+        """ + relative_date_guidelines
+
+        # ChatOpenAI LLM 호출
+        response = llm_model.invoke(prompt)
+        intent_info_json_str = response.content.strip()
+
+        # LLM 응답에서 Markdown 코드 블록 제거 후 JSON 파싱
+        if intent_info_json_str.startswith('```json') and intent_info_json_str.endswith('```'):
+            intent_info_json_str = intent_info_json_str[len('```json'):-len('```')].strip()
+        elif intent_info_json_str.startswith('```') and intent_info_json_str.endswith('```'):
+            intent_info_json_str = intent_info_json_str[len('```'):-len('```')].strip()
+
+        print(f"LLM 의도 분류 응답: {intent_info_json_str}")
+        intent_info = json.loads(intent_info_json_str)
+
+        intent = intent_info.get('intent', 'unknown')
+        query = intent_info.get('query', '')
+        date = intent_info.get('date', '')
+
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: llm_intent_classifier - 의도: {intent}, 쿼리: {query}, 날짜: {date}")
+        return {"intent": intent, "search_query": query, "search_date": date}
+
+    except Exception as e:
+        print(f"LLM 의도 분류 중 오류 발생: {e}")
+        bot_client.chat_postMessage(channel=channel_id, text=f"요청 의도를 파악하는 데 실패했습니다: {e}")
+        return {"intent": "unknown", "llm_error": f"Intent classification error: {e}"}
+
+# =============== 일정 추가 관련 노드 ================ #
+def llm_calendar_extractor(state: AgentState):
+    """
+    LLM을 사용하여 '일정 추가' 의도에서 캘린더 정보를 추출하는 노드.
+    """
+    cleaned_message = state.get("cleaned_message")
+    channel_id = state["channel_id"]
+    bot_client = state["bot_client"]
+
+    # 정제된 메시지 내용물 확인
+    if cleaned_message is None:
+        return {"llm_error": "No cleaned message to process for extraction."}
+
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: llm_calendar_extractor - LLM 호출 시작")
+
+    try:
+        prompt = (
+            f"다음 텍스트에서 '일정 제목', '시작 날짜 및 시간', '종료 날짜 및 시간'을 JSON 형식으로 추출해줘. "
+            f"현재 시각은 '{current_datetime_str}'이야. 이 정보를 기준으로 날짜와 시간을 정확히 추론해줘. "
+            f"만약 사용자가 일정의 **종료 기간, 또는 진행 시간(예: '1시간 30분', '2시간 반', '30분')**을 언급했다면, "
+            f"그 정보를 사용해서 정확한 종료 시간을 계산해줘. "
+            f"**진행 시간 언급이 없는 경우에만** 기본적으로 시작 시간에서 1시간을 더해서 종료 시간을 설정해. "
+            f"예시: '다음주 화요일 오후 5시에 회의 1시간 반 예정', '수요일 오전 11시, 30분 미팅' 등도 고려해. "
+            f"날짜 형식은 'YYYY-MM-DDTHH:MM:SS'로 맞춰줘. "
+            f"추출할 수 없는 경우 빈 문자열로 반환해줘. "
+            f"텍스트: '{cleaned_message}'"
+            f"\n\n**상대적 날짜 표현 지침:**"
+            f"\n- '오늘'은 '{datetime.now().strftime('%Y-%m-%d')}'"
+            f"\n- '내일'은 '{(datetime.now() + timedelta(days=1)).strftime('%Y-%m-%d')}'"
+            f"\n- '모레'는 '{(datetime.now() + timedelta(days=2)).strftime('%Y-%m-%d')}'"
+            f"\n- '다음주 화요일'처럼 '다음주'가 붙으면 현재 주의 다음 주 요일로 계산"
+            f"\n- '이번주 금요일'이면 이번 주의 해당 요일로 계산"
+
+            f"\n\n응답 형식:"
+            f'\n{{"subject": "일정 제목", "start_datetime": "YYYY-MM-DDTHH:MM:SS", "end_datetime": "YYYY-MM-DDTHH:MM:SS"}}'
+        )
+
+
+        # ChatOpenAI LLM 호출
+        response = llm_model.invoke(prompt)
+        date_info_json_str = response.content.strip()
+
+        print(f"LLM 응답: {date_info_json_str}")
+
+        # LLM 응답에서 Markdown 코드 블록 제거 후 JSON 파싱
+        if date_info_json_str.startswith('```json') and date_info_json_str.endswith('```'):
+            date_info_json_str = date_info_json_str[len('```json'):-len('```')].strip()
+        elif date_info_json_str.startswith('```') and date_info_json_str.endswith('```'):
+            date_info_json_str = date_info_json_str[len('```'):-len('```')].strip()
+        
+        print(f"LLM 응답 (정제 후): {date_info_json_str}")
+
+        try:
+            date_info = json.loads(date_info_json_str)
+        except json.JSONDecodeError as e:
+            print(f"JSON 파싱 오류: {e}. LLM 응답이 유효한 JSON 형식이 아닐 수 있습니다. 원본 응답: '{response.text}'")
+            bot_client.chat_postMessage(channel=channel_id, text="날짜 정보를 파싱하는 데 실패했습니다. 메시지 형식을 확인해주세요.")
+            return {"llm_error": f"JSON parsing failed: {e}"}
+
+        # 일정 정보 추출
+        subject = date_info.get('subject')
+        start_datetime_str = date_info.get('start_datetime')
+        end_datetime_str = date_info.get('end_datetime')
+
+        if subject and start_datetime_str and end_datetime_str:
+            print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: llm_calendar_extractor - 일정 정보 추출 성공: {subject}")
+            return {
+                "calendar_subject": subject,
+                "calendar_start_datetime": start_datetime_str,
+                "calendar_end_datetime": end_datetime_str
+            }
+        else:
+            bot_client.chat_postMessage(channel=channel_id, text="메시지에서 유효한 일정 정보를 찾을 수 없습니다. 예시: `@Agent이름 내일 10시 팀 회의`")
+            return {"llm_error": "No valid calendar info extracted."}
+
+    except Exception as e:
+        print(f"LLM 처리 중 오류 발생: {e}")
+        bot_client.chat_postMessage(channel=channel_id, text=f"일정을 처리하는 중 오류가 발생했습니다: {e}")
+        return {"llm_error": f"LLM processing error: {e}"}
+
+
+def add_google_calendar_event(state: AgentState):
+    """
+    추출된 캘린더 정보를 사용하여 Google Calendar에 일정을 추가하는 노드.
+    """
+    subject = state.get("calendar_subject")
+    start_datetime_str = state.get("calendar_start_datetime")
+    end_datetime_str = state.get("calendar_end_datetime")
+    cleaned_message = state.get("cleaned_message") # 내용으로 재사용
+    channel_id = state["channel_id"]
+    bot_client = state["bot_client"]
+
+    # 필수 일정 정보 누락 여부 확인 
+    if not (subject and start_datetime_str and end_datetime_str):
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: google_calendar_adder - 필수 일정 정보 누락. 캘린더 추가 건너뜀.")
+        return {"calendar_add_success": False, "calendar_add_error": "Missing calendar details."}
+
+    if not TARGET_CALENDAR_ID:
+        error_msg = "Error: GOOGLE_CALENDAR_ID 환경 변수가 설정되지 않았습니다. 일정을 추가할 수 없습니다."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"calendar_add_success": False, "calendar_add_error": error_msg}
+
+    # Google Calendar 서비스 객체 정의
+    service = get_google_calendar_service()
+
+    if not service:
+        error_msg = "Google Calendar 인증 실패로 일정을 추가할 수 없습니다. 서버 로그를 확인해주세요."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"calendar_add_success": False, "calendar_add_error": "Google Calendar service not available."}
+
+    try:
+        event = {
+            'summary': subject,
+            'description': cleaned_message, # 원본 메시지 또는 정제된 메시지를 설명으로 활용
+            'start': {
+                'dateTime': start_datetime_str,
+                'timeZone': 'Asia/Seoul',
+            },
+            'end': {
+                'dateTime': end_datetime_str,
+                'timeZone': 'Asia/Seoul',
+            },
+        }
+
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: add_google_calendar_event - Google Calendar에 이벤트 추가 시도")
+        print(f"이벤트 데이터: {json.dumps(event, indent=2, ensure_ascii=False)}")
+
+        event_response = service.events().insert(calendarId=TARGET_CALENDAR_ID, body=event).execute()
+        
+        success_msg = f"✅ '{subject}' 일정이 Google Calendar에 성공적으로 추가되었습니다."
+        bot_client.chat_postMessage(channel=channel_id, text=success_msg)
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: add_google_calendar_event - 일정 추가 성공!")
+        return {"calendar_add_success": True, "calendar_action_success": True}
+
+    except HttpError as http_err:
+        error_msg = f"❌ Google Calendar 일정 추가 중 HTTP 오류가 발생했습니다: {http_err}"
+        print(error_msg)
+        try:
+            error_details = json.loads(http_err.content.decode('utf-8'))
+            print(f"응답 본문: {json.dumps(error_details, indent=2, ensure_ascii=False)}")
+        except json.JSONDecodeError:
+            print(f"응답 본문 (JSON 아님): {http_err.content.decode('utf-8')}")
+        
+        bot_client.chat_postMessage(channel=channel_id, text="Google Calendar에 일정을 추가하는 데 실패했습니다. 서버 로그를 확인해주세요.")
+        return {"calendar_add_success": False, "calendar_add_error": str(http_err), "calendar_action_success": False}
+    except Exception as e:
+        error_msg = f"❌ Google Calendar 일정 추가 중 예상치 못한 오류가 발생했습니다: {e}"
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=f"일정을 처리하는 중 오류가 발생했습니다: {e}")
+        return {"calendar_add_success": False, "calendar_add_error": str(e), "calendar_action_success": False}
+
+
+# =============== 일정 검색 관련 노드 ================ #
+def google_calendar_searcher(state: AgentState):
+    """
+    Google Calendar에서 일정을 검색하는 노드. 주로 변경/삭제 전에 사용.
+    """
+    search_query = state.get("search_query")
+    search_date_str = state.get("search_date")
+    channel_id = state["channel_id"]
+    bot_client = state["bot_client"]
+    
+    if not TARGET_CALENDAR_ID:
+        error_msg = "Error: GOOGLE_CALENDAR_ID 환경 변수가 설정되지 않았습니다. 일정을 검색할 수 없습니다."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"found_events": [], "calendar_action_error": error_msg}
+
+    service = get_google_calendar_service()
+    if not service:
+        error_msg = "Google Calendar 인증 실패로 일정을 검색할 수 없습니다. 서버 로그를 확인해주세요."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"found_events": [], "calendar_action_error": error_msg}
+    
+    events_result = []
+    try:
+        # 현재 시간을 시스템의 로컬 시간대 정보와 함께 가져옵니다.
+        # 이 'now' 변수는 app.py 등에서 정의된 'now = datetime.now().astimezone()'와 동일한 방식으로 동작합니다.
+        current_local_time = datetime.now().astimezone()
+        
+        time_min = None
+        time_max = None
+
+        if search_date_str:
+            try:
+                # search_date_str을 파싱하여 해당 날짜의 00:00:00부터 다음 날의 00:00:00까지 설정
+                # 시간대 정보는 current_local_time의 시간대 정보를 사용합니다.
+                search_date_obj = datetime.strptime(search_date_str, '%Y-%m-%d').replace(
+                    hour=0, minute=0, second=0, microsecond=0
+                )
+                # 파싱된 날짜 객체에 현재 시스템의 시간대 정보 적용
+                search_date_obj_with_tz = current_local_time.replace(
+                    year=search_date_obj.year,
+                    month=search_date_obj.month,
+                    day=search_date_obj.day,
+                    hour=0, minute=0, second=0, microsecond=0
+                )
+                
+                time_min = search_date_obj_with_tz.isoformat()
+                time_max = (search_date_obj_with_tz + timedelta(days=1)).isoformat()
+
+                print(f"[{current_local_time.strftime('%H:%M:%S')}] 노드: google_calendar_searcher - 특정 날짜 검색 범위: timeMin={time_min}, timeMax={time_max}")
+
+            except ValueError:
+                print(f"[{current_local_time.strftime('%H:%M:%S')}] 노드: google_calendar_searcher - search_date_str 형식 오류: {search_date_str}. 현재 시간부터 검색 시도.")
+                # 날짜 형식 오류 시, timeMin을 현재 시간으로 설정하고 timeMax를 비워둠 (향후 일정 검색)
+                time_min = current_local_time.isoformat()
+                time_max = None
+        else:
+            # search_date_str이 없는 경우 (예: "회의 찾아줘"와 같이 날짜 언급 없는 경우)
+            # 현재 시간부터 이후의 일정을 검색하도록 하되, 넉넉한 기간을 설정하는 것이 좋습니다.
+            # 예시: 현재 시간부터 30일 이내의 일정 검색
+            time_min = current_local_time.isoformat()
+            time_max = (current_local_time + timedelta(days=30)).isoformat()
+            print(f"[{current_local_time.strftime('%H:%M:%S')}] 노드: google_calendar_searcher - 전체 기간 검색 범위: timeMin={time_min}, timeMax={time_max}")
+
+        # Calendar API events().list 호출
+        events_page = service.events().list(
+            calendarId=TARGET_CALENDAR_ID,
+            timeMin=time_min, # 수정된 timeMin 사용
+            timeMax=time_max, # 수정된 timeMax 사용
+            q=search_query, # 검색 키워드
+            singleEvents=True,
+            orderBy='startTime'
+        ).execute()
+        events_result = events_page.get('items', [])
+
+        if not events_result:
+            bot_client.chat_postMessage(channel=channel_id, text="검색된 일정이 없습니다. 검색어 또는 날짜를 확인해주세요.")
+            return {"found_events": [], "calendar_action_error": "No events found."}
+        
+        response_text = "검색된 일정이 있습니다:\n"
+        for i, event in enumerate(events_result):
+            start = event['start'].get('dateTime', event['start'].get('date'))
+            end = event['end'].get('dateTime', event['end'].get('date'))
+            
+            try:
+                # ISO 8601 형식 문자열을 파싱하여 로컬 시간대로 변환
+                start_dt = datetime.fromisoformat(start).astimezone(current_local_time.tzinfo)
+                formatted_start = start_dt.strftime('%m월 %d일 %H:%M')
+            except ValueError:
+                formatted_start = start # 파싱 실패 시 원본 문자열 사용
+
+            try:
+                end_dt = datetime.fromisoformat(end).astimezone(current_local_time.tzinfo)
+                formatted_end = end_dt.strftime('%H:%M')
+            except ValueError:
+                formatted_end = end # 파싱 실패 시 원본 문자열 사용
+
+            response_text += f"{i+1}. {event['summary']} (시작: {formatted_start}, 종료: {formatted_end})\n"
+        
+        # 검색된 일정이 있을 경우, 사용자가 어떤 일정을 변경/삭제할지 선택하도록 안내
+        # TODO: 사용자 추가응답 상호작용
+        if state["intent"] in ["modify", "delete"]:
+            response_text += "어떤 일정을 변경/삭제하시겠습니까? (예: '1번 변경', '2번 삭제')"
+
+        bot_client.chat_postMessage(channel=channel_id, text=response_text)
+        
+        return {"found_events": events_result}
+
+    except HttpError as http_err:
+        error_msg = f"❌ Google Calendar 일정 검색 중 HTTP 오류 발생: {http_err}"
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text="일정 검색 중 오류가 발생했습니다. 서버 로그를 확인해주세요.")
+        return {"found_events": [], "calendar_action_error": str(http_err)}
+    except Exception as e:
+        error_msg = f"❌ Google Calendar 일정 검색 중 예상치 못한 오류 발생: {e}"
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=f"일정 검색 중 오류가 발생했습니다: {e}")
+        return {"found_events": [], "calendar_action_error": str(e)}
+    
+
+# =============== 일정 변경 관련 노드 ================ #
+def llm_calendar_modifier_extractor(state: AgentState):
+    """
+    LLM을 사용하여 '일정 변경' 의도에서 변경할 일정의 새로운 정보를 추출하는 노드.
+    (예: "내일 회의를 11시로 변경해줘" -> 기존 일정 ID와 변경될 시간 정보 추출)
+    """
+    cleaned_message = state.get("cleaned_message")
+    found_events = state.get("found_events", [])
+    channel_id = state["channel_id"]
+    bot_client = state["bot_client"]
+
+    if cleaned_message is None or not found_events:
+        return {"llm_error": "No cleaned message or events for modification."}
+
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: llm_calendar_modifier_extractor - 변경 정보 추출 시작")
+    
+    # 사용자에게 제시된 일정 목록을 프롬프트에 포함
+    event_list_str = ""
+    for i, event in enumerate(found_events):
+        event_list_str += f"{i+1}. {event.get('summary', '제목 없음')} (ID: {event.get('id')})\n"
+
+    try:
+        prompt = f"""
+            현재 시각은 {current_datetime_str}야.
+            다음 메시지와 일정 목록을 바탕으로, 사용자가 **어떤 일정을 변경하고자 하는지**와
+            **어떻게 변경하고자 하는지**를 JSON 형식으로 추출해줘.
+
+            1. 일정 변경 시 규칙 : 
+            - 사용자는 기존 일정 시간과 변경할 시간을 모두 언급할 수 있어.
+            - 이때 검색 대상 일정은 '기존 시간' 기준으로 판단하고, 새로 설정할 시간은 변경된 일정 시간이야.
+            - 사용자가 진행 시간 또는 종료 시간을 명시하지 않았다면, 기존 일정의 진행시간을 유지해줘.
+            - 사용자가 '1시간 반으로 바꿔줘', '30분만 할래', '2시간 예정; 등으로 **진행 시간 변경을 요청한 경우에만**, 새 시작 시간 기준으로 종료 시간을 계산해서 바꿔줘.
+            - 만약 메시지에 ** 시작과 종료 시간이 모두 정확하게 포함되어 있다면**, 두 시간 모두 반영해줘.
+            
+            2. 날짜 형식 및 출력 관련 규칙 : 
+            날짜 형식을 'YYYY-MM-DDTHH:MM:SS'로 맞춰줘.
+            일정 번호와 변경될 정보가 없으면 빈 문자열로 반환해줘. \n
+
+            {relative_date_guidelines}
+
+            메시지: '{cleaned_message}'\n
+
+            일정 목록:\n{event_list_str}
+            
+            \n\n응답 형식: 
+            {{
+                "event_index": "변경할 일정의 0부터 시작하는 인덱스", 
+                "subject": "새 일정 제목", 
+                "start_datetime": "YYYY-MM-DDTHH:MM:SS", 
+                "end_datetime": "YYYY-MM-DDTHH:MM:SS"
+            }}
+        """
+
+        # ChatOpenAI LLM 호출
+        response = llm_model.invoke(prompt)
+        modify_info_json_str = response.content.strip()
+
+        # LLM 응답에서 Markdown 코드 블록 제거 후 JSON 파싱
+        if modify_info_json_str.startswith('```json') and modify_info_json_str.endswith('```'):
+            modify_info_json_str = modify_info_json_str[len('```json'):-len('```')].strip()
+        elif modify_info_json_str.startswith('```') and modify_info_json_str.endswith('```'):
+            modify_info_json_str = modify_info_json_str[len('```'):-len('```')].strip()
+
+        print(f"LLM 변경 정보 추출 응답: {modify_info_json_str}")
+
+        modify_info = json.loads(modify_info_json_str)
+        event_index = modify_info.get('event_index')
+        new_subject = modify_info.get('subject')
+        new_start = modify_info.get('start_datetime')
+        new_end = modify_info.get('end_datetime')
+
+        if event_index is not None and 0 <= event_index < len(found_events):
+            target_event = found_events[event_index]
+            target_event_id = target_event.get('id')
+            
+            # 변경할 정보가 없으면 원래 정보를 사용 (제목은 변경될 가능성 높음)
+            new_subject = new_subject if new_subject else target_event.get('summary')
+            new_start = new_start if new_start else target_event.get('start', {}).get('dateTime')
+            new_end = new_end if new_end else target_event.get('end', {}).get('dateTime')
+
+            print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: llm_calendar_modifier_extractor - 변경할 일정 ID: {target_event_id}")
+            return {
+                "target_event_id": target_event_id,
+                "modified_subject": new_subject,
+                "modified_start_datetime": new_start,
+                "modified_end_datetime": new_end
+            }
+        else:
+            bot_client.chat_postMessage(channel=channel_id, text="어떤 일정을 변경할지 또는 변경할 내용을 명확히 알려주세요. (예: '1번 일정을 오후 4시로 변경')")
+            return {"llm_error": "Invalid event index or missing modification details."}
+
+    except Exception as e:
+        print(f"LLM 변경 정보 추출 중 오류 발생: {e}")
+        bot_client.chat_postMessage(channel=channel_id, text=f"일정 변경 정보를 파악하는 데 실패했습니다: {e}")
+        return {"llm_error": f"LLM modification extraction error: {e}"}
+
+
+def google_calendar_updater(state: AgentState):
+    """
+    Google Calendar의 일정을 변경하는 노드.
+    """
+    target_event_id = state.get("target_event_id")
+    modified_subject = state.get("modified_subject")
+    modified_start_datetime = state.get("modified_start_datetime")
+    modified_end_datetime = state.get("modified_end_datetime")
+    channel_id = state["channel_id"]
+    bot_client = state["bot_client"]
+
+    if not (target_event_id and modified_subject and modified_start_datetime and modified_end_datetime):
+        error_msg = "일정 변경에 필요한 정보가 부족합니다."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"calendar_action_success": False, "calendar_action_error": error_msg}
+    
+    if not TARGET_CALENDAR_ID:
+        error_msg = "Error: GOOGLE_CALENDAR_ID 환경 변수가 설정되지 않았습니다. 일정을 변경할 수 없습니다."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"calendar_action_success": False, "calendar_action_error": error_msg}
+
+    service = get_google_calendar_service()
+    if not service:
+        error_msg = "Google Calendar 인증 실패로 일정을 변경할 수 없습니다. 서버 로그를 확인해주세요."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"calendar_action_success": False, "calendar_action_error": error_msg}
+
+    try:
+        updated_event = {
+            'summary': modified_subject,
+            'start': {
+                'dateTime': modified_start_datetime,
+                'timeZone': 'Asia/Seoul',
+            },
+            'end': {
+                'dateTime': modified_end_datetime,
+                'timeZone': 'Asia/Seoul',
+            },
+        }
+        
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: google_calendar_updater - 일정 변경 시도: {target_event_id}")
+        print(f"변경될 이벤트 데이터: {json.dumps(updated_event, indent=2, ensure_ascii=False)}")
+
+        event_response = service.events().update(
+            calendarId=TARGET_CALENDAR_ID,
+            eventId=target_event_id,
+            body=updated_event
+        ).execute()
+
+        success_msg = f"✅ '{modified_subject}' 일정이 성공적으로 변경되었습니다.\n"
+        bot_client.chat_postMessage(channel=channel_id, text=success_msg)
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: google_calendar_updater - 일정 변경 성공!")
+        return {"calendar_action_success": True}
+
+    except HttpError as http_err:
+        error_msg = f"❌ Google Calendar 일정 변경 중 HTTP 오류 발생: {http_err}"
+        print(error_msg)
+        try:
+            error_details = json.loads(http_err.content.decode('utf-8'))
+            print(f"응답 본문: {json.dumps(error_details, indent=2, ensure_ascii=False)}")
+        except json.JSONDecodeError:
+            print(f"응답 본문 (JSON 아님): {http_err.content.decode('utf-8')}")
+        
+        bot_client.chat_postMessage(channel=channel_id, text="일정 변경 중 오류가 발생했습니다. 서버 로그를 확인해주세요.")
+        return {"calendar_action_success": False, "calendar_action_error": str(http_err)}
+    except Exception as e:
+        error_msg = f"❌ Google Calendar 일정 변경 중 예상치 못한 오류 발생: {e}"
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=f"일정 변경 중 오류가 발생했습니다: {e}")
+        return {"calendar_action_success": False, "calendar_action_error": str(e)}
+    
+# =============== 일정 삭제 관련 노드 ================ #
+def llm_calendar_deleter_extractor(state: AgentState):
+    """
+    LLM을 사용하여 '일정 삭제' 의도에서 삭제할 일정의 번호(인덱스)를 추출하는 노드.
+    """
+    cleaned_message = state.get("cleaned_message")
+    found_events = state.get("found_events", [])
+    channel_id = state["channel_id"]
+    bot_client = state["bot_client"]
+
+    if cleaned_message is None or not found_events:
+        return {"llm_error": "No cleaned message or events for deletion."}
+
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: llm_calendar_deleter_extractor - 삭제 정보 추출 시작")
+    
+    event_list_str = ""
+    for i, event in enumerate(found_events):
+        event_list_str += f"{i+1}. {event.get('summary', '제목 없음')} (ID: {event.get('id')})\n"
+
+    try:
+        prompt = (
+            f"다음 메시지와 제공된 일정 목록을 바탕으로, 삭제하고자 하는 일정의 번호(0부터 시작하는 인덱스)를 JSON 형식으로 추출해줘. "
+            f"일정 목록:\n{event_list_str}"
+            f"메시지: '{cleaned_message}'"
+            f"\n\n응답 형식: "
+            f'{{"event_index": "삭제할 일정의 0부터 시작하는 인덱스"}}'
+        )
+        
+        # ChatOpenAI LLM 호출
+        response = llm_model.invoke(prompt)
+        delete_info_json_str = response.content.strip()
+
+        # LLM 응답에서 Markdown 코드 블록 제거 후 JSON 파싱
+        if delete_info_json_str.startswith('```json') and delete_info_json_str.endswith('```'):
+            delete_info_json_str = delete_info_json_str[len('```json'):-len('```')].strip()
+        elif delete_info_json_str.startswith('```') and delete_info_json_str.endswith('```'):
+            delete_info_json_str = delete_info_json_str[len('```'):-len('```')].strip()
+
+        print(f"LLM 삭제 정보 추출 응답: {delete_info_json_str}")
+
+        delete_info = json.loads(delete_info_json_str)
+        event_index = delete_info.get('event_index')
+
+        # event_index 타입 변환 (문쟈열 ->정수형)
+        try:
+            event_index = int(event_index)
+        except (ValueError, TypeError):
+            bot_client.chat_postMessage(channel=channel_id, text="일정 번호가 잘못 전달되었습니다. 다시 말해 주세요.")
+            return {"llm_error": "Invalid event_index type (not an int)."}
+
+        # 인덱스 유효성 검사
+        if event_index is not None and 0 <= event_index < len(found_events):
+            target_event_id = found_events[event_index].get('id')
+            print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: llm_calendar_deleter_extractor - 삭제할 일정 ID: {target_event_id}")
+            return {"target_event_id": target_event_id}
+        else:
+            bot_client.chat_postMessage(channel=channel_id, text="선택한 일정 번호가 유효하지 않습니다. 다시 확인해 주세요.")
+            return {"llm_error": "Invalid event index for deletion."}
+
+    except Exception as e:
+        print(f"LLM 삭제 정보 추출 중 오류 발생: {e}")
+        bot_client.chat_postMessage(channel=channel_id, text=f"일정 삭제 정보를 파악하는 데 실패했습니다: {e}")
+        return {"llm_error": f"LLM deletion extraction error: {e}"}
+
+def google_calendar_deleter(state: AgentState):
+    """
+    Google Calendar의 일정을 삭제하는 노드.
+    """
+    target_event_id = state.get("target_event_id")
+    channel_id = state["channel_id"]
+    bot_client = state["bot_client"]
+
+    if not target_event_id:
+        error_msg = "일정 삭제에 필요한 정보(이벤트 ID)가 부족합니다."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"calendar_action_success": False, "calendar_action_error": error_msg}
+
+    if not TARGET_CALENDAR_ID:
+        error_msg = "Error: GOOGLE_CALENDAR_ID 환경 변수가 설정되지 않았습니다. 일정을 삭제할 수 없습니다."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"calendar_action_success": False, "calendar_action_error": error_msg}
+
+    service = get_google_calendar_service()
+    if not service:
+        error_msg = "Google Calendar 인증 실패로 일정을 삭제할 수 없습니다. 서버 로그를 확인해주세요."
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=error_msg)
+        return {"calendar_action_success": False, "calendar_action_error": error_msg}
+
+    try:
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: google_calendar_deleter - 일정 삭제 시도: {target_event_id}")
+        
+        service.events().delete(
+            calendarId=TARGET_CALENDAR_ID,
+            eventId=target_event_id
+        ).execute()
+
+        success_msg = f"✅ 일정이 성공적으로 삭제되었습니다."
+        bot_client.chat_postMessage(channel=channel_id, text=success_msg)
+        print(f"[{datetime.now().strftime('%H:%M:%S')}] 노드: google_calendar_deleter - 일정 삭제 성공!")
+        return {"calendar_action_success": True}
+
+    except HttpError as http_err:
+        error_msg = f"❌ Google Calendar 일정 삭제 중 HTTP 오류 발생: {http_err}"
+        print(error_msg)
+        try:
+            error_details = json.loads(http_err.content.decode('utf-8'))
+            print(f"응답 본문: {json.dumps(error_details, indent=2, ensure_ascii=False)}")
+        except json.JSONDecodeError:
+            print(f"응답 본문 (JSON 아님): {http_err.content.decode('utf-8')}")
+        
+        bot_client.chat_postMessage(channel=channel_id, text="일정 삭제 중 오류가 발생했습니다. 서버 로그를 확인해주세요.")
+        return {"calendar_action_success": False, "calendar_action_error": str(http_err)}
+    except Exception as e:
+        error_msg = f"❌ Google Calendar 일정 삭제 중 예상치 못한 오류 발생: {e}"
+        print(error_msg)
+        bot_client.chat_postMessage(channel=channel_id, text=f"일정 삭제 중 오류가 발생했습니다: {e}")
+        return {"calendar_action_success": False, "calendar_action_error": str(e)}
+
+
+# ============ 조건부 엣지를 위한 라우터 함수 ============ #
+def route_by_intent(state: AgentState):
+    """
+    LLM이 분류한 의도(intent)에 따라 다음 노드를 결정하는 라우터.
+    """
+    intent = state.get("intent")
+    llm_error = state.get("llm_error") # LLM에서 오류가 났는지 확인
+
+    if llm_error: # LLM 처리 중 오류가 발생하면 종료
+        return "__END__" # Langgraph의 END 노드로 직접 이동하는 특별한 키워드
+
+    if intent == "add":
+        return "add"
+    elif intent in ["modify", "delete", "search"]:
+        # 변경/삭제/검색 의도는 먼저 일정 검색이 필요
+        return "search_calendar"
+    else: # "unknown" 이거나 다른 의도일 경우
+        return "__END__" # 적절한 응답 후 종료
+    
+def route_after_search(state: AgentState):
+    """
+    일정 검색 후 다음 노드를 결정하는 라우터.
+    검색된 일정이 없거나, 검색 후 사용자가 어떤 작업을 할지 명확하지 않을 때.
+    """
+    intent = state.get("intent")
+    found_events = state.get("found_events")
+    calendar_action_error = state.get("calendar_action_error") # 검색 중 오류가 있었는지
+
+    if calendar_action_error: # 검색 중 오류가 있으면 종료
+        return "__END__"
+
+    if not found_events: # 검색된 일정이 없으면 종료
+        return "__END__"
+
+    if intent == "modify":
+        return "modify"
+    elif intent == "delete":
+        return "delete"
+    elif intent == "search": # 검색만 원하는 경우, 이미 검색 결과를 Slack으로 보냈으므로 종료
+        return "__END__"
+    else:
+        # 이 경우는 발생하지 않아야 하지만, 안전장치
+        return "__END__"

--- a/ai-server/agents/schedule/agent_state.py
+++ b/ai-server/agents/schedule/agent_state.py
@@ -1,0 +1,48 @@
+# agent_state.py
+"""
+Langgraph Agent의 상태를 정의하는 파일
+이 파일은 Langgraph Agent에서 사용하는 상태를 정의합니다.
+각 노드에서 이 상태를 읽고 업데이트할 수 있습니다.
+"""
+
+from typing import TypedDict, Optional
+import slack_sdk # Slack 클라이언트 객체를 타입 힌트로 사용하기 위함
+
+class AgentState(TypedDict):
+    """
+    Langgraph Agent의 현재 상태를 나타내는 TypedDict.
+    Agent의 각 노드에서 이 상태를 읽고 업데이트할 수 있습니다.
+    """
+    slack_message: str              # 원본 Slack 메시지 텍스트
+    cleaned_message: Optional[str]  # 봇 멘션 등이 제거된 정제된 메시지
+    channel_id: str                 # 메시지가 발생한 Slack 채널 ID
+    user_id: str                    # 메시지를 보낸 사용자 ID
+    bot_client: slack_sdk.WebClient # Slack WebClient 인스턴스 (메시지 전송 등에 사용)
+
+    calendar_subject: Optional[str]         # LLM이 추출한 일정 제목
+    calendar_start_datetime: Optional[str]  # LLM이 추출한 일정 시작 시간 (ISO 8601)
+    calendar_end_datetime: Optional[str]    # LLM이 추출한 일정 종료 시간 (ISO 8601)
+    
+    llm_raw_response: Optional[str]     # LLM의 원본 응답
+    llm_error: Optional[str]            # LLM 처리 중 발생한 오류 메시지
+
+    calendar_add_success: Optional[bool]    # 캘린더 추가 성공 여부
+    calendar_add_error: Optional[str]       # 캘린더 추가 중 발생한 오류 메시지
+
+    intent: Optional[str]           # 사용자의 의도: "add", "modify", "delete", "unknown"
+    search_query: Optional[str]     # 일정 검색을 위한 키워드 (변경/삭제 시)
+    search_date: Optional[str]      # 일정 검색을 위한 날짜 (YYYY-MM-DD)
+
+    # 검색된 일정 목록 (Google Calendar Event 객체 리스트)
+    # 각 Event는 'id', 'summary', 'start', 'end' 등의 필드를 가짐
+    found_events: Optional[list[dict]] 
+    
+    target_event_id: Optional[str] # 변경/삭제 대상 일정의 고유 ID (사용자가 선택)
+
+    # 변경될 일정의 새로운 정보 (변경 시)
+    modified_subject: Optional[str]
+    modified_start_datetime: Optional[str]
+    modified_end_datetime: Optional[str]
+
+    calendar_action_success: Optional[bool] # 캘린더 변경/삭제 성공 여부
+    calendar_action_error: Optional[str]    # 캘린더 변경/삭제 중 발생한 오류 메시지

--- a/ai-server/agents/schedule/google_auth_setup.py
+++ b/ai-server/agents/schedule/google_auth_setup.py
@@ -1,0 +1,64 @@
+# =============== Google Calendar API 인증 코드, 최초 1회 실행 ================== #
+import os
+import os.path
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+# Google Calendar API의 스코프. 일정 생성 및 수정 권한
+# 필요한 최소 권한만 부여하는 것이 좋습니다.
+# 'calendar.events'는 이벤트 생성/수정/삭제 권한.
+# 'calendar'는 캘린더 설정까지 포함하는 전체 권한.
+GOOGLE_CALENDAR_SCOPES = [os.getenv('GOOGLE_CALENDAR_SCOPES')]  # google_auth_setup.py에서 사용한 것과 동일한 스코프
+
+# 스크립트 경로 정의
+BASE_DIR = os.path.dirname(__file__)
+TOKEN_PATH = os.path.join(BASE_DIR, "token.json")
+CLIENT_SECRET_PATH = os.path.join(BASE_DIR, "client_secret.json")
+
+def authenticate_google_calendar():
+    creds = None
+
+    # 토큰 파일 존재 여부 확인
+    if os.path.exists(TOKEN_PATH):
+        print("기존 token.json 파일을 사용합니다.")
+        try:
+            creds = Credentials.from_authorized_user_file(TOKEN_PATH, GOOGLE_CALENDAR_SCOPES)
+        except Exception as e:
+            print(f"[ERROR] token.json 로딩 중 오류 발생: {e}")
+            return False
+    
+    else:
+        print("token.json 파일이 존재하지 않습니다. OAuth 인증을 시작합니다.")
+
+        try:
+            # 파일에 담긴 인증 정보로 구글 서버에 인증
+            # 새 창이 열리면서 구글 로그인 및 정보 제공 동의 후 최종 인증 완료
+            flow = InstalledAppFlow.from_client_secrets_file(CLIENT_SECRET_PATH, GOOGLE_CALENDAR_SCOPES)
+            creds = flow.run_local_server(
+                port=8080,
+                access_type='offline',
+                prompt='consent'
+            )
+
+            with open(TOKEN_PATH, 'w') as token:
+                token.write(creds.to_json())
+            print("OAuth 인증 완료 및 token.json 저장 완료.") 
+        except Exception as e:
+            print(f"[ERROR] OAuth 인증 중 오류 발생: {e}")
+            return False
+
+if __name__ == '__main__':
+    print("Google Calendar API 인증 설정 스크립트를 시작합니다.")
+    print("이 스크립트는 token.json 파일을 생성하거나 갱신합니다.")
+    print("Google Cloud Console에서 다운로드한 'client_secret.json' 파일이 같은 디렉토리에 있어야 합니다.")
+    print("="*50)
+    print()
+
+    authenticate_google_calendar()
+
+    print()
+    print("="*50)
+    print("인증 설정이 완료되었습니다.")
+    print("이제 main.py를 실행하여 Google Calendar에 일정을 추가할 수 있습니다.")

--- a/ai-server/agents/schedule/langgraph_agent_definition.py
+++ b/ai-server/agents/schedule/langgraph_agent_definition.py
@@ -1,0 +1,84 @@
+# langgraph_agent_definition.py
+"""
+Langgraph Agent 정의 및 노드 설정
+"""
+
+# Langgraph 관련 임포트
+from langgraph.graph import StateGraph, END
+
+# 커스텀 모듈 임포트 (AgentState와 Agent 노드 함수들이 필요)
+# 이 파일들이 같은 디렉토리에 있다고 가정합니다.
+from agent_nodes import slack_message_parser, llm_intent_classifier, llm_calendar_extractor, \
+                        add_google_calendar_event, google_calendar_searcher, \
+                        llm_calendar_modifier_extractor, google_calendar_updater, \
+                        llm_calendar_deleter_extractor, google_calendar_deleter, \
+                        route_by_intent, route_after_search
+from agent_state import AgentState # agent_state.py에서 정의할 상태
+
+# ========= LangGraph Agent 정의 ============== #
+
+# Graph Builder 초기화
+workflow = StateGraph(AgentState)
+
+# 노드 추가
+workflow.add_node("parse_slack_message", slack_message_parser)           # 슬랙 메시지 파싱
+workflow.add_node("classify_intent", llm_intent_classifier)              # 의도 분류
+workflow.add_node("extract_calendar_info", llm_calendar_extractor)       # 일정 추가 정보 추출
+workflow.add_node("add_google_calendar_event", add_google_calendar_event)    # 구글 캘린더 일정 추가
+workflow.add_node("search_google_calendar", google_calendar_searcher)    # 일정 검색
+workflow.add_node("extract_modification_info", llm_calendar_modifier_extractor) # 변경 정보 추출
+workflow.add_node("update_google_calendar_event", google_calendar_updater)       # 일정 변경
+workflow.add_node("extract_deletion_info", llm_calendar_deleter_extractor)       # 삭제 정보 추출
+workflow.add_node("delete_google_calendar_event", google_calendar_deleter)       # 일정 삭제
+
+# 시작점 설정
+workflow.set_entry_point("parse_slack_message")
+
+# 엣지 정의
+# 1. Slack 메시지 파싱 후 항상 의도 분류 노드로
+workflow.add_edge("parse_slack_message", "classify_intent")
+
+# 2. 의도 분류 결과에 따라 분기 (조건부 엣지)
+workflow.add_conditional_edges(
+    "classify_intent", # classify_intent 노드 이후
+    route_by_intent,   # route_by_intent 함수를 호출하여 다음 노드 결정
+    {
+        "add": "extract_calendar_info", # 의도가 "add"일 때
+        "search_calendar": "search_google_calendar", # 의도가 "modify", "delete", "search"일 때
+        "__END__": END # 의도가 "unknown"이거나 오류 발생 시 종료
+    }
+)
+
+# 3. 일정 추가 정보 추출 후 캘린더 추가 노드로
+workflow.add_edge("extract_calendar_info", "add_google_calendar_event")
+
+#  4. 일정 추가 후 종료
+workflow.add_edge("add_google_calendar_event", END)
+
+# 5. 일정 검색 후 다음 노드 결정 (조건부 엣지)
+workflow.add_conditional_edges(
+    "search_google_calendar", # search_google_calendar 노드 이후
+    route_after_search, # route_after_search 함수를 호출하여 다음 노드 결정
+    {
+        "modify": "extract_modification_info", # 의도가 "modify"일 때
+        "delete": "extract_deletion_info", # 의도가 "delete"일 때
+        "__END__": END # 검색 결과가 없거나, "search" 의도일 때 종료
+    }
+)
+
+# 6. 변경 정보 추출 후 캘린더 변경 노드로
+workflow.add_edge("extract_modification_info", "update_google_calendar_event")
+
+# 7. 캘린더 변경 후 종료
+workflow.add_edge("update_google_calendar_event", END)
+
+# 8. 삭제 정보 추출 후 캘린더 삭제 노드로
+workflow.add_edge("extract_deletion_info", "delete_google_calendar_event")
+
+# 9. 캘린더 삭제 후 종료
+workflow.add_edge("delete_google_calendar_event", END)
+
+# 그래프 컴파일 및 외부로 노출
+langgraph_app = workflow.compile()
+
+# 이 파일에서 langgraph_app을 임포트하여 사용할 수 있도록 합니다.

--- a/ai-server/agents/schedule/schedule_agent.py
+++ b/ai-server/agents/schedule/schedule_agent.py
@@ -1,0 +1,149 @@
+# schedule_agent.py
+"""
+일정관리 Agent의 메인 실행 파일
+이 파일은 Slack 이벤트를 수신하고, LangGraph Agent를 실행하여
+일정을 추가/변경/삭제하는 기능을 제공합니다
+"""
+
+import slack_sdk
+from slack_sdk.errors import SlackApiError
+from datetime import datetime
+import os
+import json
+
+# Slack Bolt 관련 임포트 (Socket Mode 전용)
+from slack_bolt import App
+from slack_bolt.adapter.socket_mode import SocketModeHandler
+
+from agent_state import AgentState                   # agent_state.py에서 정의한 상태
+from langgraph_agent_definition import langgraph_app # langgraph_agent_definition.py에서 컴파일된 LangGraph 앱 임포트
+
+# 환경 변수 설정
+SLACK_BOT_TOKEN = os.getenv('SLACK_BOT_TOKEN') # Slack 봇 토큰 (xoxb- 로 시작)
+SLACK_APP_TOKEN = os.getenv('SLACK_APP_TOKEN') # Slack 앱 토큰 (xapp- 로 시작, Socket Mode에 필요)
+SIGNING_SECRET = os.getenv('SLACK_SIGNING_SECRET') # Slack 이벤트 서명 검증을 위한 시크릿
+
+# 전역 변수로 봇 사용자 ID 저장
+BOT_USER_ID = None
+
+# Slack Bolt 앱 초기화 (Socket Mode 전용)
+# 봇 토큰과 서명 시크릿을 사용하여 앱을 구성합니다.
+app_bolt = App(token=SLACK_BOT_TOKEN, signing_secret=SIGNING_SECRET)
+
+
+# 봇 사용자 ID를 가져오는 함수
+def get_bot_user_id(client):
+    """
+    Slack API를 사용하여 봇의 사용자 ID를 가져옵니다.
+    """
+    try:
+        auth_test = client.auth_test()
+        return auth_test["user_id"]
+    except SlackApiError as e:
+        print(f"Error getting bot user ID: {e}")
+        return None
+
+
+# LangGraph Agent를 실행하는 함수
+def process_slack_message(message: str, channel: str, user: str, bot_client: slack_sdk.WebClient):
+    """
+    수신된 Slack 메시지를 기반으로 LangGraph Agent를 실행하는 메인 함수
+    """
+    print(f"[{datetime.now().strftime('%H:%M:%S')}] LangGraph Agent 실행 시작: 채널({channel}), 사용자({user})")
+
+    # 1. AgentState 초기화
+    initial_state = AgentState(
+        slack_message=message,
+        channel_id=channel,
+        user_id=user,
+        bot_client=bot_client,
+
+        # 나머지 필드는 Optional이므로 초기화 시 비워둡니다.
+        cleaned_message=None,
+        calendar_subject=None,
+        calendar_start_datetime=None,
+        calendar_end_datetime=None,
+        llm_raw_response=None,
+        llm_error=None,
+        calendar_add_success=None,
+        calendar_add_error=None,
+        intent=None,
+        search_query=None,
+        search_date=None,
+        found_events=None,
+        target_event_id=None,
+        modified_subject=None,
+        modified_start_datetime=None,
+        modified_end_datetime=None,
+        calendar_action_success=None,
+        calendar_action_error=None
+    )
+
+    # 2. LangGraph 실행
+    # .stream()을 사용하면 각 노드의 출력을 실시간으로 확인할 수 있어 디버깅에 유용합니다.
+    try:
+        # 최종 결과만 필요한 경우 .invoke() 사용
+        # final_state = langgraph_app.invoke(initial_state)
+        # print("최종 상태:", final_state)
+
+        # 각 스텝을 로깅하며 실행하고 싶을 때 .stream() 사용
+        for s in langgraph_app.stream(initial_state, {"recursion_limit": 20}):
+            # 각 스텝의 상태를 출력 (디버깅용)
+            print("----------------- 스트림 출력 -----------------")
+            print(json.dumps(s, indent=2, ensure_ascii=False)) 
+            print("----------------------------------------------")
+
+    except Exception as e:
+        print(f"LangGraph 실행 중 오류 발생: {e}")
+        bot_client.chat_postMessage(channel=channel, text=f"죄송합니다. 요청을 처리하는 중에 예상치 못한 오류가 발생했습니다: {e}")
+
+
+# 'message' 이벤트 핸들러
+# 봇이 참여하고 있는 채널의 모든 메시지를 수신
+# 봇 멘션 없는 일반 메시지에서도 특정 키워드를 감지해서 처리하고 싶다면 -> 이 핸들러를 써야 함.
+# 예시) DM에서 멘션 없이 항상 반응하도록
+@app_bolt.event("message")
+def handle_message_events(body, logger, client):
+    logger.info(body) # 수신된 메시지 정보 로깅 (디버깅용)
+    event = body.get('event', {})
+    message_text = event.get('text')
+    channel_id = event.get('channel')
+
+
+# 'app_mention' 이벤트 핸들러
+# 봇이 직접 멘션(@봇이름)되었을 때만 트리거됩니다.
+@app_bolt.event("app_mention")
+def handle_app_mention_events(body, logger, client):
+    logger.info(body) # 수신된 멘션 정보 로깅 (디버깅용)
+    event = body.get('event', {})
+    message_text = event.get('text')
+    channel_id = event.get('channel')
+    user_id = event.get('user') # 사용자 ID 추가
+
+    # 여기서 우리 봇이 멘션되었는지 명시적으로 확인합니다.
+    if message_text and channel_id and f'<@{BOT_USER_ID}>' in message_text:
+        # 이전 답변에서 제안한 process_slack_message 함수를 호출합니다.
+        process_slack_message(message=message_text, channel=channel_id, user=user_id, bot_client=client)
+    else:
+        # 우리 봇의 멘션이 없는 메시지는 무시합니다.
+        logger.info(f"봇 멘션이 없어 메시지를 건너뜜: {message_text}")
+
+
+# 메인 실행 블록
+# Socket Mode 핸들러를 시작하여 Slack 이벤트 수신을 시작합니다.
+if __name__ == "__main__":
+    # Slack WebClient 초기화 (봇 ID 획득용)
+    # SocketModeHandler가 시작되기 전에 봇 ID를 미리 가져옵니다.
+    slack_web_client_for_init = slack_sdk.WebClient(token=SLACK_BOT_TOKEN)
+    BOT_USER_ID = get_bot_user_id(slack_web_client_for_init)
+
+    if BOT_USER_ID is None:
+        print("Fatal Error: 봇 사용자 ID를 가져올 수 없습니다. 애플리케이션을 종료합니다.")
+        exit(1) # 봇 ID 없으면 실행 중단
+
+    print("Slack Agent가 Socket Mode로 시작됩니다.")
+    print("슬래시 커맨드(/schedule)는 지원되지 않습니다. Agent를 멘션(@Agent이름)하여 일정을 추가해주세요.")
+    
+    # Socket Mode 핸들러 시작
+    handler = SocketModeHandler(app_bolt, SLACK_APP_TOKEN)
+    handler.start()

--- a/ai-server/main.py
+++ b/ai-server/main.py
@@ -7,7 +7,8 @@ import os
 from dotenv import load_dotenv
 import openai
 import json
-
+import subprocess
+import sys
 
 from agents import CodeAgent
 from agents.rag_agent import RAGAgent
@@ -347,6 +348,16 @@ async def add_documents_to_rag(file_paths: List[str]):
         raise HTTPException(
             status_code=500, detail=f"문서 추가 중 오류가 발생했습니다: {str(e)}"
         )
+
+@app.on_event("startup")
+async def start_schedule_agent():
+    """서버 시작 시 Schedule Agent를 백그라운드에서 실행"""
+    schedule_agent_path = os.path.join(os.path.dirname(__file__), "agents/schedule/schedule_agent.py")
+
+    # 현재 FastAPI가 실행 중인 Python 인터프리터 경로를 그대로 이용
+    current_python = sys.executable
+
+    subprocess.Popen([current_python, schedule_agent_path])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### 일정관리 Agent
- Slack API를 통한 Google Calendar 일정 추가/변경/검색/삭제
- Slack bot 멘션 후, 요청사항 입력 (ex: 내일 오후 2시에 테스트 미팅 추가해줘.)
<br />

### 개선 및 보완점
- [ ] **검색 기능 개선**
- 검색 키워드 필터링 느슨하게 적용 : 키워드가 완전히 일치하지 않아도 유사한 표현이면 일정 검색
- 사용자의 2차 추가 응답 : 검색된 일정이 여러 개 있을 경우, 어떤 일정을 선택할 것인지 추가 응답을 받고 변경/삭제 진행 (미정)
- [ ] **수정 기능 개선**
- <**어떤 일정을 변경하고자 하는지**>와 <**어떻게 변경하고자 하는지**> 정확히 분류   
<br />

### 일정 관리 추가 테스트 사진
<img width="431" height="88" alt="테스트예시" src="https://github.com/user-attachments/assets/766068b3-5f2e-478d-ab5f-ca6cb5ff858d" />

